### PR TITLE
Add someOrValid and Field#option

### DIFF
--- a/modules/core/src/main/scala/fields/Field.scala
+++ b/modules/core/src/main/scala/fields/Field.scala
@@ -22,10 +22,10 @@ final case class Field[+P](
     value: P,
 ) {
 
-  /** Returns name of the [[jap.fields.Field]] */
+  /** Returns [[jap.fields.FieldPath.name]] of `path` */
   val name = path.name
 
-  /** Returns full path of the field. It is dot-separated path of this [[jap.fields.Field]] */
+  /** Returns [[jap.fields.FieldPath.full]] of `path` */
   val fullPath = path.full
 
   /** Creates new [[jap.fields.Field]] with provided `value` and `name`. Prepends current fields `path` to this field
@@ -39,25 +39,28 @@ final case class Field[+P](
   def selectSub[S](name: String, selector: P => S): Field[S] = Field(path + name, selector(value))
 
   /** Renames this [[jap.fields.Field]]. Changes last `path` part aka name. */
-  def named(name: String): Field[P] = Field(path.named(name), value)
+  def named(name: String): Field[P] = withPath(path.named(name))
 
-  /** Change [[Field.path]] */
-  def withPath(newPath: FieldPath): Field[P] = Field(newPath, value)
+  /** Change `path` */
+  def withPath(newPath: FieldPath): Field[P] = copy(path = newPath)
 
-  /** Change [[Field.value]] */
-  def withValue[V](newValue: V): Field[V] = Field(path, newValue)
+  /** Change `value` */
+  def withValue[V](newValue: V): Field[V] = copy(value = newValue)
 
-  /** Map [[Field.value]] */
+  /** Maps `value` */
   def map[B](f: P => B): Field[B] = withValue(f(value))
 
-  /** Map [[Field.path]] */
+  /** Maps `path` */
   def mapPath(f: FieldPath => FieldPath): Field[P] = withPath(f(this.path))
 
-  /** Given [[Field.value]] type is Tuple, get first tuple element */
+  /** Gets first tuple element of `value`. Given [[P]] is Tuple */
   def first[P1, P2](implicit ev: P <:< (P1, P2)): Field[P1] = map(ev(_)._1)
 
-  /** Given [[Field.value]] type is Tuple, get second tuple element */
+  /** Gets second tuple element of `value`. Given [[P]] is Tuple */
   def second[P1, P2](implicit ev: P <:< (P1, P2)): Field[P2] = map(ev(_)._2)
+
+  /** Turns Option on `value` into Option on `jap.fields.Field`. Given [[P]] i `Option[V]` */
+  def option[V](implicit ev: P <:< Option[V]): Option[Field[V]] = ev(value).map(withValue)
 
   override def toString = fullPath + ":" + value
 }

--- a/modules/core/src/test/scala/validation/FieldSuite.scala
+++ b/modules/core/src/test/scala/validation/FieldSuite.scala
@@ -17,4 +17,8 @@ class FieldSuite extends munit.FunSuite {
     val field = Field("a", "a")
     assertEquals(field.selectSub("A", _.toUpperCase), Field(FieldPath.raw("a.A"), "A"))
   }
+  test("Field.option") {
+    assertEquals(Field(Some(2)).option, Some(Field(2)))
+    assertEquals(Field[Option[Int]](None).option, None)
+  }
 }

--- a/modules/core/src/test/scala/validation/OptionSyntaxSuite.scala
+++ b/modules/core/src/test/scala/validation/OptionSyntaxSuite.scala
@@ -1,0 +1,33 @@
+package jap.fields
+
+import FieldPathConversions._
+import DefaultAccumulateVM._
+import ValidationError._
+import scala.util.Properties
+
+class OptionSyntaxSuite extends munit.FunSuite {
+  test("Option.some") {
+    assertEquals(Field(Some(2)).some(_ > 10).errors, List(Greater(FieldPath.Root, "10")))
+    assertEquals(Field[Option[Int]](None).some(_ > 10).errors, Nil)
+  }
+  test("Option.isSome/isNone") {
+    val someF = Field(Some(2))
+    val noneF = Field[Option[Int]](None)
+    assertEquals(someF.isSome.errors, Nil)
+    assertEquals(noneF.isSome.errors, List(Empty(someF)))
+    assertEquals(someF.isNone.errors, List(NonEmpty(someF)))
+    assertEquals(noneF.isNone.errors, Nil)
+  }
+  test("Option.someOrValid") {
+    val fo1        = Field(Option(3))
+    val fo2        = Field(Option(4))
+    val rule: Rule =
+      someOrValid(
+        for {
+          f1 <- fo1.option
+          f2 <- fo2.option
+        } yield (f1 > f2)
+      )
+    assertEquals(rule.errors, List(Greater(fo1, fo2.fullPath)))
+  }
+}

--- a/modules/core/src/test/scala/validation/SyntaxSuite.scala
+++ b/modules/core/src/test/scala/validation/SyntaxSuite.scala
@@ -93,17 +93,6 @@ class SyntaxSuite extends munit.FunSuite {
       ),
     )
   }
-  test("Some.some") {
-    val someF = Field(Some(2))
-    assertEquals(
-      someF.some(_ > 10).errors,
-      Greater(someF, "10") :: Nil,
-    )
-  }
-  test("None.some") {
-    val noneF: Field[Option[Int]] = Field(None)
-    assertEquals(noneF.some(_ > 10).errors, Nil)
-  }
   test("String.isEnum") {
     assert(Field("Red").isEnum(RGB).isValid)
     assert(Field("Purple").isEnum(RGB).isInvalid)


### PR DESCRIPTION
This gives ability to have better looking API for Option validation and to prevent callback hell when using OptionSyntax#some.

For example this
```scala
aOpt.some(a => bOpt.some(b => a == b))
```
Can be rewritten like
```scala
someOrValid(
  for {
    a <- aOpt.option
    b <- bOpt.option
  } yield (a == b)
)
aOpt.some(a => bOpt.some(b => a == b))
```
Or using Cats 
```scala 
  (aOpt, bOpt).mapN(_ == _)
```
