### PR TITLE
feat: make FieldPath tagged

### DIFF
--- a/modules/core/src/main/scala/fields/Field.scala
+++ b/modules/core/src/main/scala/fields/Field.scala
@@ -16,6 +16,8 @@
 
 package jap.fields
 
+import FieldPath._
+
 /** [[jap.fields.Field]] is heart of the library and contains [[jap.fields.FieldPath]] and its value */
 final case class Field[+P](
     path: FieldPath,

--- a/modules/core/src/main/scala/fields/package.scala
+++ b/modules/core/src/main/scala/fields/package.scala
@@ -22,4 +22,7 @@ package object fields {
     * for Rule. Also we get ability to convert back and forth.
     */
   type Rule[+F[_], +V[_], +E] <: Rule.Type[F, V, E]
+
+  /** Contains path parts of the Field */
+  type FieldPath <: FieldPath.Type
 }

--- a/modules/core/src/test/scala/fields/FieldPathSuite.scala
+++ b/modules/core/src/test/scala/fields/FieldPathSuite.scala
@@ -16,7 +16,7 @@ class FieldPathSuite extends munit.FunSuite {
   ).foreach { case (field, expected) =>
     test(s"FieldPath.full/toString - $expected") {
       assertEquals(field.full, expected)
-      assertEquals(field.toString, expected)
+      assertEquals(field.toString, expected.split('.').toList.toString)
     }
   }
 


### PR DESCRIPTION
Seems like List looks OK. 
Making FieldPath Tagged is a good decision for cases when user will use FieldPath in collections but there is one issue with this - it is impossible to override toString. 
Leaving this here as this point is debatable.
fixes #31 
